### PR TITLE
Adapt Makefile of the extension for some PGXS versions

### DIFF
--- a/pg/Makefile
+++ b/pg/Makefile
@@ -28,3 +28,6 @@ REGRESS_OPTS = --inputdir='$(TEST_DIR)' --outputdir='$(TEST_DIR)'
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+# This seems to be needed at least for PG 9.3.11
+all: $(DATA)


### PR DESCRIPTION
Postgresql 9.3.11 doesn't generates $DATA by default.
fixes #4 

Please @ohasselblad test this in your local environment; make sure the crankdown--XXXX.sql file is generated when you run `sudo make install` in the pg subdirectory (or `sudo make install` in the top directory).