### PR TITLE
fixing cluster query tests

### DIFF
--- a/src/py/crankshaft/test/test_clustering_moran.py
+++ b/src/py/crankshaft/test/test_clustering_moran.py
@@ -60,10 +60,10 @@ class MoranTest(unittest.TestCase):
 
         ans = "SELECT i.\"cartodb_id\" As id, i.\"andy\"::numeric As attr1, " \
               "i.\"jay_z\"::numeric As attr2, (SELECT ARRAY(SELECT j.\"cartodb_id\" " \
-              "FROM \"(SELECT * FROM a_list)\" As j WHERE j.\"andy\" IS NOT NULL AND " \
+              "FROM (SELECT * FROM a_list) As j WHERE j.\"andy\" IS NOT NULL AND " \
               "j.\"jay_z\" IS NOT NULL AND j.\"jay_z\" <> 0 ORDER BY " \
               "j.\"the_geom\" <-> i.\"the_geom\" ASC LIMIT 321 OFFSET 1 ) ) " \
-              "As neighbors FROM \"(SELECT * FROM a_list)\" As i WHERE i.\"andy\" IS NOT " \
+              "As neighbors FROM (SELECT * FROM a_list) As i WHERE i.\"andy\" IS NOT " \
               "NULL AND i.\"jay_z\" IS NOT NULL AND i.\"jay_z\" <> 0 ORDER " \
               "BY i.\"cartodb_id\" ASC;"
 
@@ -74,10 +74,10 @@ class MoranTest(unittest.TestCase):
 
         ans = "SELECT i.\"cartodb_id\" As id, i.\"andy\"::numeric As attr1, " \
               "i.\"jay_z\"::numeric As attr2, (SELECT ARRAY(SELECT " \
-              "j.\"cartodb_id\" FROM \"(SELECT * FROM a_list)\" As j WHERE ST_Touches(" \
+              "j.\"cartodb_id\" FROM (SELECT * FROM a_list) As j WHERE ST_Touches(" \
               "i.\"the_geom\", j.\"the_geom\") AND j.\"andy\" IS NOT NULL " \
               "AND j.\"jay_z\" IS NOT NULL AND j.\"jay_z\" <> 0)) As " \
-              "neighbors FROM \"(SELECT * FROM a_list)\" As i WHERE i.\"andy\" IS NOT NULL " \
+              "neighbors FROM (SELECT * FROM a_list) As i WHERE i.\"andy\" IS NOT NULL " \
               "AND i.\"jay_z\" IS NOT NULL AND i.\"jay_z\" <> 0 ORDER BY " \
               "i.\"cartodb_id\" ASC;"
 
@@ -88,10 +88,10 @@ class MoranTest(unittest.TestCase):
 
         ans = "SELECT i.\"cartodb_id\" As id, i.\"andy\"::numeric As attr1, " \
               "i.\"jay_z\"::numeric As attr2, (SELECT ARRAY(SELECT " \
-              "j.\"cartodb_id\" FROM \"(SELECT * FROM a_list)\" As j WHERE j.\"andy\" IS " \
+              "j.\"cartodb_id\" FROM (SELECT * FROM a_list) As j WHERE j.\"andy\" IS " \
               "NOT NULL AND j.\"jay_z\" IS NOT NULL AND j.\"jay_z\" <> 0 " \
               "ORDER BY j.\"the_geom\" <-> i.\"the_geom\" ASC LIMIT 321 " \
-              "OFFSET 1 ) ) As neighbors FROM \"(SELECT * FROM a_list)\" As i WHERE " \
+              "OFFSET 1 ) ) As neighbors FROM (SELECT * FROM a_list) As i WHERE " \
               "i.\"andy\" IS NOT NULL AND i.\"jay_z\" IS NOT NULL AND " \
               "i.\"jay_z\" <> 0 ORDER BY i.\"cartodb_id\" ASC;"
 
@@ -106,6 +106,7 @@ class MoranTest(unittest.TestCase):
 
     def test_get_weight(self):
         """Test get_weight."""
+        ## need to add tests
 
         self.assertEqual(True, True)
 


### PR DESCRIPTION
this removes unneeded `"` left in the test queries

cc @jgoizueta 