### PR TITLE
Check up to date with master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ before_install:
   # save the postgres port for later usage
   - sudo cat /etc/postgresql/9.5/main/postgresql.conf | grep ^port | grep -oh '[0-9]*' > .pg95.port
 
-script:
+install:
   - sudo make install
+
+script:
   - PGPORT=$(cat .pg95.port) make test || { cat src/pg/test/regression.diffs; false; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 before_install:
+  - ./check-up-to-date-with-master.sh
   - sudo apt-get -y install python-pip
 
   - sudo apt-get -y install python-software-properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,8 @@ before_install:
     | sudo tee /etc/postgresql/9.5/main/pg_hba.conf
   - sudo /etc/init.d/postgresql restart 9.5
 
-  # save the postgres port for later usage
-  - sudo cat /etc/postgresql/9.5/main/postgresql.conf | grep ^port | grep -oh '[0-9]*' > .pg95.port
-
 install:
   - sudo make install
 
 script:
-  - PGPORT=$(cat .pg95.port) make test || { cat src/pg/test/regression.diffs; false; }
+  - make test || { cat src/pg/test/regression.diffs; false; }

--- a/check-up-to-date-with-master.sh
+++ b/check-up-to-date-with-master.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Add remote-master
+git remote add -t master remote-master https://github.com/CartoDB/crankshaft.git
+
+# Fetch master reference
+git fetch --depth=1 remote-master master
+
+# Compare HEAD with master
+# NOTE: travis by default uses --depth=50 so we are actually checking that the tip
+# of the branch is no more than 50 commits away from master as well.
+git rev-list HEAD | grep $(git rev-parse remote-master/master) ||
+    { echo "Your branch is not up to date with latest release";
+      echo "Please update it by running the following:";
+      echo "    git fetch && git merge origin/develop";
+      false; }


### PR DESCRIPTION
Another easy review:
- check that the branch is up to date with latest release, by making sure tip of master is among the ancestors of the current branch.
- split into `install` and `script` phases (mostly cosmetic)
- remove the PGPORT hack (not needed after purging exisiting pg packages)

@ethervoid can you please review?
 
