### PR TITLE
Compatibility checks - take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,4 @@ install:
 
 script:
   - make test || { cat src/pg/test/regression.diffs; false; }
+  - ./check-compatibility.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 
+env:
+  global:
+    - PAGER=cat
+
 before_install:
   - ./check-up-to-date-with-master.sh
   - sudo apt-get -y install python-pip

--- a/check-compatibility.sh
+++ b/check-compatibility.sh
@@ -50,11 +50,13 @@ EOF
 
 # TODO save public functions and signatures
 
+# Deploy current dev branch
+make clean-dev || die "Could not clean dev files"
+sudo make install || die "Could not deploy current dev branch"
+
 # Check it can be upgraded
 psql $DBNAME -c "ALTER EXTENSION crankshaft update to 'dev';" || die "Cannot upgrade to dev version"
 
 
 
 # TODO check against saved public functions and signatures
-
-

--- a/check-compatibility.sh
+++ b/check-compatibility.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+export PGUSER=postgres
+
+DBNAME=crankshaft_compatcheck
+
+function die {
+    echo $1
+    exit -1
+}
+
+# Create fresh DB
+psql -c "CREATE DATABASE $DBNAME;" || die "Could not create DB"
+
+# Hook for cleanup
+function cleanup {
+    psql -c "DROP DATABASE IF EXISTS crankshaft_compatcheck;"
+}
+trap cleanup EXIT
+
+# Deploy previous release
+(cd src/py && sudo make deploy RUN_OPTIONS="--no-deps") || die "Could not deploy python extension"
+(cd src/pg && sudo make deploy) || die " Could not deploy last release"
+psql -c "SELECT * FROM pg_available_extension_versions WHERE name LIKE 'crankshaft';"
+
+# Install in the fresh DB
+psql $DBNAME <<'EOF'
+-- Install dependencies
+CREATE EXTENSION plpythonu;
+CREATE EXTENSION postgis VERSION '2.2.2';
+
+-- Create role publicuser if it does not exist
+DO
+$$
+BEGIN
+   IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_user
+      WHERE  usename = 'publicuser') THEN
+
+      CREATE ROLE publicuser LOGIN;
+   END IF;
+END
+$$ LANGUAGE plpgsql;
+
+-- Install the default version
+CREATE EXTENSION crankshaft;
+\dx
+EOF
+
+# TODO save public functions and signatures
+
+# Check it can be upgraded
+psql $DBNAME -c "ALTER EXTENSION crankshaft update to 'dev';" || die "Cannot upgrade to dev version"
+
+
+
+# TODO check against saved public functions and signatures
+
+

--- a/check-compatibility.sh
+++ b/check-compatibility.sh
@@ -48,7 +48,26 @@ CREATE EXTENSION crankshaft;
 \dx
 EOF
 
-# TODO save public functions and signatures
+# Save public function signatures
+psql $DBNAME <<'EOF'
+CREATE TABLE release_function_signatures AS
+  SELECT
+    p.proname as name,
+    pg_catalog.pg_get_function_result(p.oid) as result_type,
+    pg_catalog.pg_get_function_arguments(p.oid) as arguments,
+   CASE
+    WHEN p.proisagg THEN 'agg'
+    WHEN p.proiswindow THEN 'window'
+    WHEN p.prorettype = 'pg_catalog.trigger'::pg_catalog.regtype THEN 'trigger'
+    ELSE 'normal'
+   END as type
+  FROM pg_catalog.pg_proc p
+       LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  WHERE
+       n.nspname = 'cdb_crankshaft'
+       AND p.proname LIKE 'cdb_%'
+  ORDER BY 1, 2, 4;
+EOF
 
 # Deploy current dev branch
 make clean-dev || die "Could not clean dev files"
@@ -57,6 +76,33 @@ sudo make install || die "Could not deploy current dev branch"
 # Check it can be upgraded
 psql $DBNAME -c "ALTER EXTENSION crankshaft update to 'dev';" || die "Cannot upgrade to dev version"
 
+# Check against saved public function signatures
+psql $DBNAME <<'EOF'
+CREATE TABLE dev_function_signatures AS
+  SELECT
+    p.proname as name,
+    pg_catalog.pg_get_function_result(p.oid) as result_type,
+    pg_catalog.pg_get_function_arguments(p.oid) as arguments,
+   CASE
+    WHEN p.proisagg THEN 'agg'
+    WHEN p.proiswindow THEN 'window'
+    WHEN p.prorettype = 'pg_catalog.trigger'::pg_catalog.regtype THEN 'trigger'
+    ELSE 'normal'
+   END as type
+  FROM pg_catalog.pg_proc p
+       LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  WHERE
+       n.nspname = 'cdb_crankshaft'
+       AND p.proname LIKE 'cdb_%'
+  ORDER BY 1, 2, 4;
+EOF
 
+echo "Functions in development not in latest release (ok):"
+psql $DBNAME -c "SELECT * FROM dev_function_signatures EXCEPT SELECT * FROM release_function_signatures;"
 
-# TODO check against saved public functions and signatures
+echo "Functions in latest release not in development (compat issue):"
+psql $DBNAME -c "SELECT * FROM release_function_signatures EXCEPT SELECT * FROM dev_function_signatures;"
+
+# Fail if there's a signature mismatch / missing functions
+psql $DBNAME -c "SELECT * FROM release_function_signatures EXCEPT SELECT * FROM dev_function_signatures;" | fgrep '(0 rows)' \
+    || die "Function signatures changed"

--- a/src/pg/.gitignore
+++ b/src/pg/.gitignore
@@ -4,3 +4,4 @@ results/
 crankshaft--dev.sql
 crankshaft--dev--current.sql
 crankshaft--current--dev.sql
+crankshaft--*--dev.sql

--- a/src/pg/Makefile
+++ b/src/pg/Makefile
@@ -10,13 +10,14 @@ include ../../Makefile.global
 # * test runs the tests for the currently generated Development
 #   extension.
 
-DATA         = $(EXTENSION)--dev.sql \
-	             $(EXTENSION)--current--dev.sql \
-	             $(EXTENSION)--dev--current.sql
+DATA = \
+    $(EXTENSION)--dev.sql \
+    $(EXTENSION)--current--dev.sql \
+    $(EXTENSION)--dev--current.sql \
+    $(EXTENSION)--$(RELEASE_VERSION)--dev.sql
 
 SOURCES_DATA_DIR = sql
 SOURCES_DATA = $(wildcard $(SOURCES_DATA_DIR)/*.sql)
-
 
 REPLACEMENTS = -e 's/@@VERSION@@/$(EXTVERSION)/g'
 

--- a/src/pg/sql/04_py_agg.sql
+++ b/src/pg/sql/04_py_agg.sql
@@ -10,10 +10,22 @@ CREATE OR REPLACE FUNCTION
     END
     $$ LANGUAGE plpgsql;
 
-
-CREATE AGGREGATE CDB_PyAgg(NUMERIC[])(
-    SFUNC = CDB_PyAggS,
-    STYPE = Numeric[],
-    INITCOND = "{}" 
-);
-
+-- Create aggregate if it did not exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT *
+        FROM pg_catalog.pg_proc p
+            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'cdb_crankshaft'
+            AND p.proname = 'cdb_pyagg'
+            AND p.proisagg)
+    THEN
+        CREATE AGGREGATE CDB_PyAgg(NUMERIC[]) (
+            SFUNC = CDB_PyAggS,
+            STYPE = Numeric[],
+            INITCOND = "{}"
+        );
+    END IF;
+END
+$$ LANGUAGE plpgsql;

--- a/src/pg/sql/11_kmeans.sql
+++ b/src/pg/sql/11_kmeans.sql
@@ -41,9 +41,23 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-CREATE AGGREGATE CDB_WeightedMean(geometry(Point, 4326), NUMERIC)(
-    SFUNC = CDB_WeightedMeanS,
-    FINALFUNC = CDB_WeightedMeanF,
-    STYPE = Numeric[],
-    INITCOND = "{0.0,0.0,0.0}" 
-);
+-- Create aggregate if it did not exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT *
+        FROM pg_catalog.pg_proc p
+            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'cdb_crankshaft'
+            AND p.proname = 'cdb_weightedmean'
+            AND p.proisagg)
+    THEN
+        CREATE AGGREGATE CDB_WeightedMean(geometry(Point, 4326), NUMERIC) (
+            SFUNC = CDB_WeightedMeanS,
+            FINALFUNC = CDB_WeightedMeanF,
+            STYPE = Numeric[],
+            INITCOND = "{0.0,0.0,0.0}" 
+        );
+    END IF;
+END
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
What this does:
- it takes the latest released version, installs it and tests that it can be easily upgraded to the current dev branch
- it also checks public function signatures looking for incompatibilities
- some fixes for compatibility (create aggregations if not exists)

@ethervoid can you please review?

cc/ @luisbosque @rochoa The idea is to simplify the dev process as much as we can, avoiding the generation for upgrade/downgrade paths. Actually I think the downgrade path can be obviated (look to the future). Feedback and suggestions are more than welcomed.

cc/ @stuartlynn @ohasselblad 