### PR TITLE
HOTFIX barycenter method

### DIFF
--- a/src/pg/sql/08_interpolation.sql
+++ b/src/pg/sql/08_interpolation.sql
@@ -74,11 +74,11 @@ BEGIN
                 SELECT array_agg(v) INTO vertex FROM a;
 
             -- retrieve the value of each vertex
-        WITH a AS(SELECT unnest(vertex) as geo, unnest(colin) as c)
+        WITH a AS(SELECT unnest(geomin) as geo, unnest(colin) as c)
             SELECT c INTO va FROM a WHERE ST_Equals(geo, vertex[1]);
-        WITH a AS(SELECT unnest(vertex) as geo, unnest(colin) as c)
+        WITH a AS(SELECT unnest(geomin) as geo, unnest(colin) as c)
             SELECT c INTO vb FROM a WHERE ST_Equals(geo, vertex[2]);
-        WITH a AS(SELECT unnest(vertex) as geo, unnest(colin) as c)
+        WITH a AS(SELECT unnest(geomin) as geo, unnest(colin) as c)
                 SELECT c INTO vc FROM a WHERE ST_Equals(geo, vertex[3]);
 
         SELECT ST_area(g), ST_area(ST_MakePolygon(ST_MakeLine(ARRAY[point, vertex[2], vertex[3], point]))), ST_area(ST_MakePolygon(ST_MakeLine(ARRAY[point, vertex[1], vertex[3], point]))), ST_area(ST_MakePolygon(ST_MakeLine(ARRAY[point,vertex[1],vertex[2], point]))) INTO sg, sa, sb, sc;


### PR DESCRIPTION
Just merge it :grin: 

- [ ] All declared geometries are `geometry(Geometry, 4326)` for general geoms, or `geometry(Point, 4326)`
- [ ] Existing functions in crankshaft python library called from the extension are kept at least from version N to version N+1 (to avoid breakage during upgrades).
- [ ] Docs for public-facing functions are written
- [ ] New functions follow the naming conventions: `CDB_NameOfFunction`. Where internal functions begin with an underscore `_`.
- [ ] If appropriate, new functions accepts an arbitrary query as an input (see [Crankshaft Issue #6](https://github.com/CartoDB/crankshaft/issues/6) for more information)
 

