### PR TITLE
[FIX] Voronoi spurious segments [09]

### DIFF
--- a/doc/09_voronoi.md
+++ b/doc/09_voronoi.md
@@ -27,9 +27,12 @@ PostGIS wil include this in future versions ([doc for dev branch](http://postgis
 ```sql
 WITH a AS (
     SELECT
-    ARRAY[ST_GeomFromText('POINT(2.1744 41.403)'),ST_GeomFromText('POINT(2.1228 41.380)'),ST_GeomFromText('POINT(2.1511 41.374)'),ST_GeomFromText('POINT(2.1528 41.413)'),ST_GeomFromText('POINT(2.165 41.391)'),ST_GeomFromText('POINT(2.1498 41.371)'),ST_GeomFromText('POINT(2.1533 41.368)'),ST_GeomFromText('POINT(2.131386 41.41399)')] AS geomin
+    ARRAY[ST_GeomFromText('POINT(2.1744 41.403)', 4326),ST_GeomFromText('POINT(2.1228 41.380)', 4326),ST_GeomFromText('POINT(2.1511 41.374)', 4326),ST_GeomFromText('POINT(2.1528 41.413)', 4326),ST_GeomFromText('POINT(2.165 41.391)', 4326),ST_GeomFromText('POINT(2.1498 41.371)', 4326),ST_GeomFromText('POINT(2.1533 41.368)', 4326),ST_GeomFromText('POINT(2.131386 41.41399)', 4326)] AS geomin
 )
 SELECT
-    CDB_voronoi(geomin, 0.2, 1e-9) as result
+    st_transform(
+    (st_dump(CDB_voronoi(geomin, 0.2, 1e-9)
+    )).geom
+        , 3857) as the_geom_webmercator
 FROM a;
 ```

--- a/src/pg/sql/09_voronoi.sql
+++ b/src/pg/sql/09_voronoi.sql
@@ -25,7 +25,7 @@ BEGIN
     convexhull_1 as (
         SELECT
             ST_ConvexHull(ST_Collect(geomin)) as g,
-            buffer * |/ st_area(ST_ConvexHull(ST_Collect(geomin))) as r
+            buffer * |/ (st_area(ST_ConvexHull(ST_Collect(geomin)))/PI()) as r
     ),
     clipper as(
         SELECT
@@ -153,7 +153,8 @@ BEGIN
     INTO geomout
     FROM
         voro_set v,
-        clipper c;
+        clipper c
+    WHERE ST_GeometryType(v.g) = 'ST_Polygon';
     RETURN geomout;
 END;
 $$ language plpgsql IMMUTABLE;

--- a/src/pg/test/expected/09_voronoi_test.out
+++ b/src/pg/test/expected/09_voronoi_test.out
@@ -2,6 +2,6 @@ SET client_min_messages TO WARNING;
 \set ECHO none
        avg_area       
 ----------------------
- 0.000178661712160428
+ 0.000178661700690617
 (1 row)
 

--- a/src/pg/test/expected/09_voronoi_test.out
+++ b/src/pg/test/expected/09_voronoi_test.out
@@ -2,6 +2,6 @@ SET client_min_messages TO WARNING;
 \set ECHO none
        avg_area       
 ----------------------
- 0.000200480682454162
+ 0.000178661712160428
 (1 row)
 


### PR DESCRIPTION
* Removes the unwanted segments
* Tweak the buffering code to be more strict


- [x] All declared geometries are `geometry(Geometry, 4326)` for general geoms, or `geometry(Point, 4326)`
- [x] Existing functions in crankshaft python library called from the extension are kept at least from version N to version N+1 (to avoid breakage during upgrades).
- [x] Docs for public-facing functions are written
- [x] New functions follow the naming conventions: `CDB_NameOfFunction`. Where internal functions begin with an underscore `_`.
- [x] If appropriate, new functions accepts an arbitrary query as an input (see [Crankshaft Issue #6](https://github.com/CartoDB/crankshaft/issues/6) for more information)
 
