### PR TITLE
Reorder package installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ before_install:
   - sudo apt-get -y install postgresql-9.5=9.5.2-2ubuntu1
   - sudo apt-get -y install postgresql-server-dev-9.5=9.5.2-2ubuntu1
   - sudo apt-get -y install postgresql-plpython-9.5=9.5.2-2ubuntu1
-  - sudo apt-get -y install postgresql-9.5-postgis-2.2=2.2.2.0-cdb2
   - sudo apt-get -y install postgresql-9.5-postgis-scripts=2.2.2.0-cdb2
+  - sudo apt-get -y install postgresql-9.5-postgis-2.2=2.2.2.0-cdb2
 
   # configure it to accept local connections from postgres
   - echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" \


### PR DESCRIPTION
Fixes #138
It seems that package postgresql-9.5-postgis-2.2 is now
indirectly depending on postgresql-9.5-postgis-2.3-scripts which
is not compatible with the packages in cartodb launchpad repos