### PR TITLE
Upgrade pysal to version 1.14.3

### DIFF
--- a/src/py/crankshaft/requirements.txt
+++ b/src/py/crankshaft/requirements.txt
@@ -1,5 +1,5 @@
 joblib==0.8.3
 numpy==1.6.1
 scipy==0.14.0
-pysal==1.11.2
+pysal==1.14.3
 scikit-learn==0.14.1

--- a/src/py/crankshaft/setup.py
+++ b/src/py/crankshaft/setup.py
@@ -41,7 +41,7 @@ setup(
     # The choice of component versions is dictated by what's
     # provisioned in the production servers.
     # IMPORTANT NOTE: please don't change this line. Instead issue a ticket to systems for evaluation.
-    install_requires=['joblib==0.8.3', 'numpy==1.6.1', 'scipy==0.14.0', 'pysal==1.11.2', 'scikit-learn==0.14.1'],
+    install_requires=['joblib==0.8.3', 'numpy==1.6.1', 'scipy==0.14.0', 'pysal==1.14.3', 'scikit-learn==0.14.1'],
 
     requires=['pysal', 'numpy', 'sklearn'],
 


### PR DESCRIPTION
This solves a problem with the Markov analysis. Otherwise, with some
inputs it gives the following error:

```
Analysis A2 failed:
ValueError: operands could not be broadcast together with shapes (5) (3)
```

The stack trace is the following:
```
ERROR:  ValueError: operands could not be broadcast together with shapes (5) (2)
CONTEXT:  Traceback (most recent call last):
  PL/Python function "cdb_spatialmarkovtrend", line 7, in <module>
    return markov.spatial_trend(subquery, time_cols, num_classes, w_type, num_ngbrs, permutations, geom_col, id_col)
  PL/Python function "cdb_spatialmarkovtrend", line 76, in spatial_trend
  PL/Python function "cdb_spatialmarkovtrend", line 416, in __init__
  PL/Python function "cdb_spatialmarkovtrend", line 498, in _mn_test
  PL/Python function "cdb_spatialmarkovtrend", line 526, in _ssmnp_test
PL/Python function "cdb_spatialmarkovtrend"
```

and here is the line where it actually fails:
https://github.com/pysal/pysal/blob/v1.11.2/pysal/spatial_dynamics/markov.py#L526

In v1.14.3, the `shtest` is opt-in. So this gives us a chance to curate data if we wanted to apply that test, optionally, instead of crashing:

https://github.com/pysal/pysal/blob/v1.14.3/pysal/spatial_dynamics/markov.py#L490


- [x] All declared geometries are `geometry(Geometry, 4326)` for general geoms, or `geometry(Point, 4326)`
- [x] Existing functions in crankshaft python library called from the extension are kept at least from version N to version N+1 (to avoid breakage during upgrades).
- [x] Docs for public-facing functions are written
- [x] New functions follow the naming conventions: `CDB_NameOfFunction`. Where internal functions begin with an underscore
- [x] Video explaining the analysis and showing examples 
- [x] Analysis Documentation written [template](https://docs.google.com/a/cartodb.com/document/d/1X2KOtaiEBKWNMp8UjwcLB-kE9aIOw09aOjX3oaCjeME/edit?usp=sharing)
- [ ] Smoke test written
- [x] Hand-off document for camshaft node written
- [x] If function is in Python, code conforms to [PEP8 Style Guide](https://www.python.org/dev/peps/pep-0008/)
